### PR TITLE
Hook Documents improvement

### DIFF
--- a/entities/hooks/hook.d.ts
+++ b/entities/hooks/hook.d.ts
@@ -8,6 +8,7 @@ export default interface IHook {
     HookParameters?: {[key: string]: string};
     ReturnBehavior: ReturnBehaviour;
     TargetType: string;
+    NeedReturnType?: string;
     Category: string;
     MethodData: {
         MethodName: string;

--- a/util/hooks.ts
+++ b/util/hooks.ts
@@ -8,12 +8,26 @@ export function getHookJson() {
   return hooks.Hooks.filter(hook => hook.Category !== "_Patches" && !hook.HookName.includes("["));
 }
 
+// Get the return type of the hook from the CodeAfterInjection
+function getReturnTypeFromCodeAfterInjection(hook: IHook): string | null {
+  if (!hook.CodeAfterInjection) return null;
+  
+  const code = hook.CodeAfterInjection.replace(/global::/g, '');
+  const typeMatch = /\breturnvar is ([a-zA-Z0-9:\.]+)/.exec(code);
+  if (typeMatch && typeMatch[1]) return typeMatch[1];
+  return null;
+}
+
 export function getGroupedHooks() {
   const hooksJson = getHookJson();
 
   var out = {} as { [key: string]: { [key: string]: IHook[] } };
 
   hooksJson.forEach((hook) => {
+    const returnType = getReturnTypeFromCodeAfterInjection(hook);
+    if (returnType) {
+      hook.NeedReturnType = returnType;
+    }
     if (!out[hook.Category]) {
       out[hook.Category] = {};
     }


### PR DESCRIPTION
Added the correct return type instead of void and edited the example for each return value.

**NeedReturnType** has been added to the **IHook**. 
This will allow you to get the desired type to be returned. 
Parsing value from **IHook.CodeAfterInjection** using regex.