### PR TITLE
HookDescription

### DIFF
--- a/docs/hooks/[category]/[hook].paths.ts
+++ b/docs/hooks/[category]/[hook].paths.ts
@@ -86,7 +86,7 @@ function getHookDescription(hooks: IHook[]) {
 
   for (const hook of hooks) {
     if (hook.HookDescription && !output.includes(hook.HookDescription)) {
-      output.push(hook.HookDescription);
+      output.push(hook.HookDescription.replace("\r", "  "));
     }
   }
 

--- a/docs/hooks/[category]/[hook].paths.ts
+++ b/docs/hooks/[category]/[hook].paths.ts
@@ -86,7 +86,7 @@ function getHookDescription(hooks: IHook[]) {
 
   for (const hook of hooks) {
     if (hook.HookDescription && !output.includes(hook.HookDescription)) {
-      output.push(hook.HookDescription.replace("\r", "  "));
+      output.push(hook.HookDescription.replace(/\r/g, "  "));
     }
   }
 


### PR DESCRIPTION
added HookDescription.replace("\r", "  ") to do a crlf on the page
not sure why the /r/n is already converted to just /r 